### PR TITLE
Add Option to apply context menu item to ALL files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To use the context menu item, follow these steps:
    - Run the `install.exe` file.
    - By default, it will use the path `C:\Users\%USERNAME%\AppData\Local\Programs\cursor\Cursor.exe` for the Cursor application.
    - If you want to use a custom path for the Cursor executable, provide the path as a command-line argument when running `install.exe`.
+   - You can also provide the command-line argument `-a` to install the context menu item for all files, not just directories.
 
 3. **Uninstall the Context Menu Item:**
    - Run the `uninstall.exe` file to remove the context menu item.

--- a/install.cpp
+++ b/install.cpp
@@ -88,7 +88,7 @@ bool FileExists(const std::string& path)
     return (attrib != INVALID_FILE_ATTRIBUTES && !(attrib & FILE_ATTRIBUTE_DIRECTORY));
 }
 
-bool InstallContextMenu(const std::string& exePath)
+bool InstallContextMenu(const std::string& exePath, bool installForAllFiles)
 {
     if (!FileExists(exePath))
     {
@@ -96,7 +96,7 @@ bool InstallContextMenu(const std::string& exePath)
         return false;
     }
 
-    std::string subKey = "Directory\\Background\\shell\\Open with Cursor";
+    std::string subKey = installForAllFiles ? "*\\shell\\Open with Cursor" : "Directory\\Background\\shell\\Open with Cursor";
     std::string commandKey = subKey + "\\command";
 
     if (!CreateRegistryKey(HKEY_CLASSES_ROOT, subKey.c_str(), NULL, "Open with Cursor"))
@@ -117,6 +117,7 @@ bool InstallContextMenu(const std::string& exePath)
 
 int main(int argc, char* argv[])
 {
+    bool installForAllFiles = false;
     if (!IsElevated())
     {
         RunAsAdmin(argv[0], (argc > 1) ? argv[1] : "");
@@ -124,9 +125,16 @@ int main(int argc, char* argv[])
     }
 
     std::string exePath = GetCursorPath();
-    if (argc > 1)
+    for (int i = 1; i < argc; i++)
     {
-        exePath = argv[1];
+        const std::string arg = std::string(argv[i]);
+        if (arg == "-a" || arg == "--all")
+        {
+            installForAllFiles = true;
+        }
+        else {
+            exePath = arg;
+        }
     }
 
     if (exePath.empty())

--- a/uninstall.cpp
+++ b/uninstall.cpp
@@ -12,10 +12,11 @@ bool DeleteRegistryKey(HKEY hKeyParent, LPCSTR subKey) {
 
 bool UninstallContextMenu() {
     std::string subKey = "Directory\\Background\\shell\\Open with Cursor";
-    if (!DeleteRegistryKey(HKEY_CLASSES_ROOT, subKey.c_str())) {
-        return false;
-    }
-    return true;
+    std::string subKeyAll = "*\\shell\\Open with Cursor";
+    bool success = DeleteRegistryKey(HKEY_CLASSES_ROOT, subKey.c_str());
+    bool successAll = DeleteRegistryKey(HKEY_CLASSES_ROOT, subKeyAll.c_str());
+
+    return success || successAll;
 }
 
 int main() {


### PR DESCRIPTION
This change allows users to add the '-a' runtime argument which installs the context menu item for all file types, not just directories (like the VS Code context menu item).